### PR TITLE
Fixed contradicting convar "sv_vote_issue_pause_match_spec_only"

### DIFF
--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -591,7 +591,6 @@ sv_server_graphic2
 sv_steamgroup
 sv_steamgroup_exclusive
 sv_voiceenable
-sv_vote_issue_pause_match_spec_only
 sv_vote_quorum_ratio
 sv_vote_timer_duration
 tv_advertise_watchable


### PR DESCRIPTION
The convar "sv_vote_issue_pause_match_spec_only" is listed twice. Once in the list of convars that must have an exact value and once under the category with more freedom.

Based on the in-game description of this cvar - "When enabled, only admins start technical pause" and given that it should be set to 1, I assume this was done to prevent some sort of abuse by the players hence why removed it from the other list.

Feel free to make the change the other way around by leaving it in the loose convar list and removing it from the strict one.