### PR TITLE
Fix mistype information related to RMR rules

### DIFF
--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -211,7 +211,7 @@ The RMR format for a region is determined by the number of slots for that region
 		- The remaining two teams play a best of 3 and the loser is eliminated.
 
 		4 teams: both 3-0 teams and two of the three 3-1 teams.
-		- The three 3-2 teams are first sorted by difficulty score. 
+		- The three 3-1 teams are first sorted by difficulty score. 
 		- The lower two teams play a best of 3 and the loser is eliminated. 	
 		
 		5 teams: both 3-0 teams and all three 3-1 teams.


### PR DESCRIPTION
Fix rule related to RMR with 4 invites. Instead of classifying the 3-2 teams, it should be 3-1.