### PR TITLE
Throw better error message when country region could not be found

### DIFF
--- a/regional_standings/model/util/region.js
+++ b/regional_standings/model/util/region.js
@@ -263,8 +263,12 @@ var regionMap = [
 ];
 
 function getCountryRegion( playerCountry ){
+    let record = regionMap.find( el => el.countrycode.toLowerCase() === playerCountry.toLowerCase() );
+    
+    if (!record) {
+        throw new Error( `Country region could not be found for ${playerCountry}` );
+    }
 
-    let record = regionMap.filter( el => el.countrycode.toLowerCase() === playerCountry.toLowerCase() )[0];
     let region = record.region;
 
     if ( region === 'EU' ){


### PR DESCRIPTION
- Replace .filter() with .find()
- In the scenario that a record with a countrycode which matches the playerCountry could not be found, throw an error with a better error message