### PR TITLE
Fixed off-by-one error in opponent winnings and victories.

### DIFF
--- a/regional_standings/model/team.js
+++ b/regional_standings/model/team.js
@@ -188,10 +188,10 @@ class Team {
             } );
     
             bounties.sort( (a,b) => b - a );
-            team.opponentWinnings = bounties.slice(0,(bucketSize - 1)).reduce( (a,b) => a + b, 0 ) / bucketSize;
+            team.opponentWinnings = bounties.slice(0,bucketSize).reduce( (a,b) => a + b, 0 ) / bucketSize;
 
             network.sort( (a,b) => b - a );
-            team.opponentVictories = network.slice(0,(bucketSize - 1)).reduce( (a,b) => a + b, 0 ) / bucketSize;
+            team.opponentVictories = network.slice(0,bucketSize).reduce( (a,b) => a + b, 0 ) / bucketSize;
         } );
 
         // Finally, build modifiers from calculated values


### PR DESCRIPTION
In the process of analyzing how the rankings are calculated I noticed a discrepancy in my computations versus `team.opponentWinnings` and `team.opponentVictories`. The issue seems to be that `Array.slice` is non-inclusive on the end, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice.

Thus, the modifiers bountyCollected and opponentNetwork are underestimated for all teams - and thus lessens their impact on the ranking. Below is the top 10 ranking in Europe based on `matchdata.json` provided in the repo with and without the change. Seed refers to the initial seed given to the ELO ranking before the matches are "run". Whilst the ranking does not change in this small sample, most teams are affected by 4-6 points.

### Standings as of 2023-02-12, with correct slice.
| Standing | Team Name     |    Seed | Points |
| -: | :- | -: | -: |
|        1 | G2            | 1000.00 |   1077 |
|        2 | Heroic        |  946.76 |    961 |
|        3 | FaZe          |  928.88 |    948 |
|        4 | Liquid        |  955.88 |    923 |
|        5 | Natus Vincere |  918.71 |    911 |
|        6 | Outsiders     |  873.58 |    883 |
|        7 | Vitality      |  865.25 |    878 |
|        8 | OG            |  838.26 |    829 |
|        9 | Astralis      |  764.51 |    829 |
|       10 | fnatic        |  812.05 |    820 |

### Standings as of 2023-02-12, with incorrect slice.
| Standing | Team Name     |    Seed | Points |
| -: | :- | -: | -: |
|        1 | G2            | 1000.00 |   1078 |
|        2 | Heroic        |  950.59 |    965 |
|        3 | FaZe          |  934.59 |    953 |
|        4 | Liquid        |  959.49 |    927 |
|        5 | Natus Vincere |  923.65 |    916 |
|        6 | Outsiders     |  880.20 |    889 |
|        7 | Vitality      |  871.60 |    884 |
|        8 | OG            |  845.21 |    835 |
|        9 | Astralis      |  766.55 |    832 |
|       10 | fnatic        |  816.76 |    825 |


