### PR TITLE
Define eligible rosters for wildcard invites

### DIFF
--- a/tournament-wilcard-invite-eligible-rosters.md
+++ b/tournament-wilcard-invite-eligible-rosters.md
@@ -14,6 +14,8 @@ The following is a list of rosters that achieved eligibility to receive a Wildca
 | Spirit | chopper, sh1ro, magixx, zont1x, donk | 2025-02-09 | Tier 1 |
 | MOUZ | Brollan, torzsi, Spinx, Jimpphat, xertioN | 2025-02-23 | Tier 1 |
 | Falcons | NiKo, Magisk, TeSeS, degster, kyxsan | 2025-02-23 | Tier 1 |
+| Vitality | apEX, ropz, ZywOo, flameZ, mezii | 2025-03-16 | Tier 1 |
+| MOUZ | Brollan, torzsi, Spinx, Jimpphat, xertioN | 2025-03-16 | Tier 1 |
 | Shimmer | Stx, empathy, Fawx, raven, milo | 2025-01-04 | Tier 2 |
 | 500 | SPELLAN, CeRz, SHiPZ, Rainwaker, oxygeN | 2025-02-15 | Tier 2 |
 | Partizan | emi, c0llins, Kind0, Dragon, VLDN | 2025-02-15 | Tier 2 |
@@ -31,3 +33,25 @@ The following is a list of rosters that achieved eligibility to receive a Wildca
 | Victores Sumus | Benzene, arakyN, Recoilmaster, ChAmP, RaYzEr | 2025-03-01 | Tier 2 |
 | BLUEJAYS | Fruitcupx, snav, SLIGHT, freshie, Wolffe | 2025-03-02 | Tier 2 |
 | Marsborne | chop, Grizz, motm, WolfY, Minus | 2025-03-02 | Tier 2 |
+| BC.Game | jkaem, nexa, nawwk, CYPHER, pr1metapz | 2025-03-11 | Tier 2 |
+| fnatic | KRIMZ, blameF, fear, MATYS, Burmylov | 2025-03-11 | Tier 2 |
+| Fluxo | arT, piriajr, kye, history, mlhzin | 2025-03-11 | Tier 2 |
+| ShindeN | BK1, nacho, abizz, roy, ivz | 2025-03-11 | Tier 2 |
+| OG | nicodooz, F1KU, spooke, Buzz, Chr1zN | 2025-03-16 | Tier 2 |
+| 500 | SPELLAN, CeRz, SHiPZ, Rainwaker, oxygeN | 2025-03-16 | Tier 2 |
+| Chinggis Warriors | NEUZ, ROUX, ariucle, controlez, Efire | 2025-03-16 | Tier 2 |
+| The Huns | nin9, yAmi, Bart4k, Veccil, cobra | 2025-03-16 | Tier 2 |
+| Iberian Soul | alex, mopoz, stadodo, sausol, dav1g | 2025-03-16 | Tier 2 |
+| Leca | opdust, M1KA, snowiee, ZPX, h0t | 2025-03-16 | Tier 2 |
+| Spray Jutsu | OxygeN, rinn, dosikzz, ElayDzha, 1Drezz | 2025-03-16 | Tier 2 |
+| Delta | ddoni, mixmeister, dosikk, tsukumeow, dune | 2025-03-16 | Tier 2 |
+| RUBY | fozil, H4SAN4TOR, sowalio, Kaide, mo0N | 2025-03-22 | Tier 2 |
+| NEVERMORE | MUV, neiter, doni, hodix, jackast | 2025-03-22 | Tier 2 |
+| LOBOARMY | zockie, Slayerhz, BabyRage, SJR, Antuanette | 2025-03-23 | Tier 2 |
+| anything else | Slash, K4mr0, cypress, FAME, mcniff | 2025-03-23 | Tier 2 |
+| SemperFi | aliStair, keen, Valiance, shadiy, SaVage | 2025-03-23 | Tier 2 |
+| ex-TALON | malta, sterling, hazr, nettik, ADDICT | 2025-03-23 | Tier 2 |
+| Gods Reign | Rossi, Bhavi, Ph1NNN, f1redup, R2B2 | 2025-03-23 | Tier 2 |
+| Come Mid | HSB, SOULM8, x1ron, PokemoN, Dili | 2025-03-23 | Tier 2 |
+| Flshbck | EmbeR, clouda, DEFAULTER, CycloneF, reV3nnnn | 2025-03-26 | Tier 2 |
+| Victores Sumus | Recoilmaster, p7, Benzene, ChAmP, RaYzEr | 2025-03-26 | Tier 2 |


### PR DESCRIPTION
There is no public list of rosters that are eligible for wildcard invites, nor do HLTV distinguish completed tournaments' tiers, only whether or not they were ranked.

For example, in the case of a completed ranked tournament such as CyberX Championship, both K27 and TigeRES are eligible for wildcard invites, but there is no publicly available tournament tier, only the tournament was ranked. This means that there is no clear indication for Tournament Operators if a roster is eligible to fulfill the requirements.

![image](https://github.com/user-attachments/assets/756a704f-cc20-4161-890f-0897d8a6659b)