### PR TITLE
Updating tournament-operation-requirements.md

### DIFF
--- a/tournament-operation-requirements.md
+++ b/tournament-operation-requirements.md
@@ -231,7 +231,6 @@ c) Tier 2 Tournament that do not feature any VRS invitations: two weeks before t
 4.4 **Verifiability of Data**
 
 - Any published information must be published on a platform that does not allow modification of past posts (e.g., X.com), preserves version history (e.g., Github.com), or it must be preserved on an independent archiving platform (e.g., Internet Archive's Wayback Machine).
-- If the event has "first-come-first-served" registration, then rosters' registration time and order needs to be publicly inspectable (e.g. Google form registration that posts to a view-only publicly visible sheet that contains timestamps.)
 
 
 ### 5. Competition / Integrity.


### PR DESCRIPTION
With the current implementation and validation of this rule, it provides little benefit / difference.

I would assume the reason for its implementation is to ensure further clarity and authenticity on that first come first served registration is being handled correctly and specific teams arent being benefitted or whitelisted.

However, given the current rule and its verification, very little has changed and the problem I would presume this tried to fixed, can still occur.

For example, BC Game masters is using a [published HTML sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vSnsa_jwmmFPR2MmQu4BJ8jZm5Gt_0BLLS86T5oekGOT_LRiKOfaLMLclrHwPzH9Lvs1EML-WM2FV1j/pubhtml) that is a manually edited sheet populating signups. While I dont believe there has been any misconduct and im not trying to suggest so, manually edited HTML sheets being allowed would surely defeat the purpose of the rule. While its populated with timestamps, its not publicly inspectable such that it can be proved an edit was not manual inserted into the true order of signups / has the original timestamp.

There are other tournaments using published HTML sheets, and while the edit log isnt visible you can at least test to see if its being automatically populated, but an edit wouldnt be visible unless it is continually watched and there is no inspectable log.

Ideally, if the aim is to ensure signups are authentic, the sheet itself should be shared so a valid form response embed is visible, for example what [FERJEE In House is doing](https://docs.google.com/spreadsheets/d/1TQP0NkERfnegAshAWXpxJmNufqBpw3kr5H-AVCtv9xQ/edit?gid=147809878#gid=147809878). 

In an ideal world, the public signup sheet would be setup such that the edit log is inspectable. On coverage submission a TO can add an editor to the sheet and can still leave the form response page itself as protected, but the editor will be able to retroactively inspect the edit logs and can identify the authenticity with "Form responses" being directly from the form itself.
<img width="1911" height="497" alt="image" src="https://github.com/user-attachments/assets/367c8bdd-cbfe-4936-9baa-b4d1f9196aae" />

I could be wrong and this may be the intention of the rule, it is not currently being enforced though.
